### PR TITLE
issue-9 Travis-CI build status is now on README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-mspar
+mspar [![Build Status](https://travis-ci.org/cmontemuino/mspar.svg?branch=master)](https://travis-ci.org/cmontemuino/mspar)
 =====
 
 Parallel version of "ms" coalescent simulator using a master worker approach and a MPI implementation with on-demand scheduling.


### PR DESCRIPTION
Added the Travis-CI build status image to the README file.
